### PR TITLE
Ensure all downloads use get.php

### DIFF
--- a/src/utils/book_formatter.py
+++ b/src/utils/book_formatter.py
@@ -175,6 +175,7 @@ class BookFormatter:
             url = link.get('url', '')
             text = link.get('text', f'Download {i}')
             mirror = link.get('mirror', '')
+            filename = link.get('filename')
             
             # Clean up link text
             clean_text = self._clean_link_text(text)
@@ -183,8 +184,14 @@ class BookFormatter:
             if mirror:
                 mirror_name = self._extract_domain_name(mirror)
                 clean_text += f" ({mirror_name})"
+            
+            # Prefer showing filename if available
+            if filename:
+                display_text = f"{clean_text} - {filename}"
+            else:
+                display_text = clean_text
                 
-            formatted_links.append(f"🔸 <a href='{url}'>{clean_text}</a>")
+            formatted_links.append(f"🔸 <a href='{url}'>{display_text}</a>")
             
         return '\n'.join(formatted_links)
         


### PR DESCRIPTION
Resolve `get.php` download links to their final URLs and extract filenames to provide direct download links and better file information.

---
<a href="https://cursor.com/background-agent?bcId=bc-b315cf42-6995-4e7b-bdaa-2fce49a5a8c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b315cf42-6995-4e7b-bdaa-2fce49a5a8c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

